### PR TITLE
Add cuda based sparse linear solver for big problems

### DIFF
--- a/pysdot/solvers/CuPyx.py
+++ b/pysdot/solvers/CuPyx.py
@@ -1,0 +1,22 @@
+
+import numpy as np
+import cupy as cp
+from cupyx.scipy.sparse import csr_matrix
+from cupyx.linalg.sparse.solve import lschol
+    
+class Solver:
+    def __init__(self):
+        self.dtype = np.float64
+
+    def create_matrix(self, N, *args):
+        (offsets, columns, values) = map(cp.asarray, args)
+        return csr_matrix((values, columns, offsets))
+
+    def create_vector(self, values=None, size=0):
+        if (values is None):
+            return cp.zeros(size, dtype=self.dtype)
+        return cp.asarray(values, dtype=self.dtype)
+
+    # solution of Ax = B
+    def solve(self, A, b):
+        return cp.asnumpy(lschol(A, b))


### PR DESCRIPTION
For optimization based problems based on pysdot, more than 75% of evaluation time is passed in sparse linear system solving.
This pull request adds a CUDA based sparse linear solver based on the cupy library, in addition to already supported scipy and PETSc CPU based solvers.

Acceleration will depend on problem size, GPU hardware and CPU<->GPU PCI bandwidth. 
For medium sized problems such as 128x128 diracs and 128x128 image domains I get an acceleration factor of around 3.5.
Cupy requires cuda 10 and precompiled binaries can be installed with `pip install cupy-cuda102` (for CUDA 10.2).

Also the verbosity parameter can now be tweaked directly at OptimalTransport.__init__.